### PR TITLE
change how with is used in schemas

### DIFF
--- a/schemas.dhall
+++ b/schemas.dhall
@@ -22,12 +22,14 @@ let defaultMetadata =
 
 let File =
     -- base File type with contents of type T
-          \(T : Type)
-      ->  { Type = Metadata //\\ { contents : T }, default = defaultMetadata }
+      \(T : Type) ->
+        { Type = Metadata //\\ { contents : T }, default = defaultMetadata }
 
 let withFormat =
     -- File with a specific format
-      \(format : Format) -> \(T : Type) -> File T with default.format = format
+      \(format : Format) ->
+      \(T : Type) ->
+        let file = File T in file with default.format = format
 
 let TextFile = withFormat Format.Raw Text
 
@@ -35,7 +37,7 @@ let YAMLFile = withFormat Format.YAML
 
 let JSONFile = withFormat Format.JSON
 
-let Executable = withFormat Format.Raw Text with default.executable = True
+let Executable = TextFile with default.executable = True
 
 in  { File
     , Format


### PR DESCRIPTION
I ran into some syntax errors around the `with` operator when following the bootstrapping steps. These are the two changes I had to make and it seems happy now!

```
➔ echo '(./files.dhall).files.dhall-render.contents' | dhall text | ruby
dhall:
↳ ./files.dhall
  ↳ https://raw.githubusercontent.com/timbertson/dhall-render/7f41fbfdfb86e1b9bbbf614a6577979bd91c07b1/package.dhall
    ↳ https://raw.githubusercontent.com/timbertson/dhall-render/7f41fbfdfb86e1b9bbbf614a6577979bd91c07b1/schemas.dhall
Error: Invalid input
https://raw.githubusercontent.com/timbertson/dhall-render/7f41fbfdfb86e1b9bbbf614a6577979bd91c07b1/schemas.dhall:30:51:
   |
30 |       \(format : Format) -> \(T : Type) -> File T with default.format = format
   |                                                   ^^
unexpected "wi"
expecting ->, :, keyword, or whitespace
1│ ./schemas.dhall
https://raw.githubusercontent.com/timbertson/dhall-render/7f41fbfdfb86e1b9bbbf614a6577979bd91c07b1/package.dhall:1:1
```