### PR TITLE
Output pretty json

### DIFF
--- a/bin/dhall-render
+++ b/bin/dhall-render
@@ -10,7 +10,7 @@ require 'open3'
 
 FORMATTERS = {
 	'YAML' => -> (contents) { contents.to_yaml },
-	'JSON' => -> (contents) { contents.to_json },
+  'JSON' => -> (contents) { JSON.pretty_generate(contents) },
 	'Raw' => -> (contents) {
 		raise "Raw file must be a string, got #{contents.class}" unless contents.is_a? String
 		contents

--- a/bin/dhall-render
+++ b/bin/dhall-render
@@ -10,7 +10,7 @@ require 'open3'
 
 FORMATTERS = {
 	'YAML' => -> (contents) { contents.to_yaml },
-  'JSON' => -> (contents) { JSON.pretty_generate(contents) },
+	'JSON' => -> (contents) { JSON.pretty_generate(contents) },
 	'Raw' => -> (contents) {
 		raise "Raw file must be a string, got #{contents.class}" unless contents.is_a? String
 		contents

--- a/lib/dhall_render.rb
+++ b/lib/dhall_render.rb
@@ -10,7 +10,7 @@ require 'open3'
 
 FORMATTERS = {
 	'YAML' => -> (contents) { contents.to_yaml },
-	'JSON' => -> (contents) { contents.to_json },
+	'JSON' => -> (contents) { JSON.pretty_generate(contents) },
 	'Raw' => -> (contents) {
 		raise "Raw file must be a string, got #{contents.class}" unless contents.is_a? String
 		contents


### PR DESCRIPTION
`dhall-to-json` prints pretty json, but during the processing in ruby we lose that and are currently printing ugly one line JSON output.

This adds pretty printing json by default. Dhall has this set by default, I would assume that's what this script should do too.

TODO: Is there any way to test this script within this repo?