### PR TITLE
dhall-render: Added support for YAML stream documents

### DIFF
--- a/lib/dhall_render.rb
+++ b/lib/dhall_render.rb
@@ -5,11 +5,16 @@ require 'json'
 require 'find'
 require 'fileutils'
 require 'open3'
+require 'psych'
 
 @default_path = 'files.dhall'
 
 FORMATTERS = {
 	'YAML' => -> (contents) { contents.to_yaml },
+	'YAMLStream' => -> (contents) {
+    		raise "YAMLStream must be an array, got #{contents.class}" unless contents.is_a? Array
+    		Psych.dump_stream(contents)
+  	},
 	'JSON' => -> (contents) { JSON.pretty_generate(contents) },
 	'Raw' => -> (contents) {
 		raise "Raw file must be a string, got #{contents.class}" unless contents.is_a? String


### PR DESCRIPTION
Kubernetes and yaml stream/multi documents sitting in a 🌴 

Support writing this type if the `contents` input is a list, with each document encoded.

I'm not sure if psych is the right module to work here, but it worked out of the box for me.

Feel free to use some other module if there's any you prefer.