### PR TITLE
Fix regex for parentheses workaround

### DIFF
--- a/maintenance/fix
+++ b/maintenance/fix
@@ -76,7 +76,7 @@ def main
 				if options[:fix_imports]
 					# workaround https://github.com/dhall-lang/dhall-haskell/issues/1672
 					contents = File.read(path)
-					fixed = contents.gsub(/(http[^ ]+ using) ([.\\\/~][^ ]+) (sha256:[^ $])/) do |x|
+					fixed = contents.gsub(/(http[^ ]+ using) ([.\\\/~][^ ]+?)\n\s+(sha256:[^ ]+$)/) do |x|
 						match = Regexp.last_match
 						"#{match[1]} (#{match[2]}) #{match[3]}"
 					end


### PR DESCRIPTION
Fixes an issue where the parentheses workaround for https://github.com/dhall-lang/dhall-haskell/issues/1672 was broken. After the dhall freeze step happens [here](https://github.com/timbertson/dhall-render/compare/master...ckumar1:fix-paren-workaround-regex?expand=1#diff-b629585c5a8be8292326db3ae43ced63c53919b5d083c4aea756cb764689056cL93), the remote import in `contents`  actually gets broken into two lines and looks like this for classic:

```
let groups =
      https://raw.githubusercontent.com/zendesk/config-service-data/3b1d6774838796c47908710bf8dde95a67308ea5/generated/dhall/data/shared_env_groups/package.dhall using ./github-headers.dhall
        sha256:54b2af133f73f77b919d53229c61c3d9288096207e796c27229b7cd653824a14
```

The following regex addresses this case, but I am open to workshopping it to be more robust if we know what other forms this could take.