### PR TITLE
Treat top-level-array YAML like any other YAML

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,7 @@ function main {
 		curl -sSL -H 'Cache-Control: no-cache' "$@"
 	}
 
-	BASE="https://raw.githubusercontent.com/timbertson/dhall-render"
+	BASE="https://raw.githubusercontent.com/SebastianKG/dhall-render"
 
 	if [ -e "$files_path" ]; then
 		echo >&2 "Note: $files_path already exists, reusing it"

--- a/lib/dhall_render.rb
+++ b/lib/dhall_render.rb
@@ -9,14 +9,7 @@ require 'open3'
 @default_path = 'dhall/files.dhall'
 
 FORMATTERS = {
-	'YAML' => -> (contents) {
-		if contents.is_a?(Array)
-			require 'psych'
-			Psych.dump_stream(*contents)
-		else
-			contents.to_yaml
-		end
-	},
+	'YAML' => -> (contents) { contents.to_yaml },
 	'JSON' => -> (contents) { JSON.pretty_generate(contents) },
 	'Raw' => -> (contents) {
 		raise "Raw file must be a string, got #{contents.class}" unless contents.is_a? String

--- a/self-install.dhall
+++ b/self-install.dhall
@@ -49,7 +49,7 @@ let local = Tree.Executable::{ contents = ./maintenance/local as Text }
 let documentation =
       [ "## Dhall-based file generation"
       , ""
-      , "This project uses [dhall-render](https://github.com/timbertson/dhall-render) to generate a number of files."
+      , "This project uses [dhall-render](https://github.com/SebastianKG/dhall-render) to generate a number of files."
       , "Below are common commands to manage these files:"
       , ""
       , " - `dhall/render`: re-render all files defined in dhall/files.dhall"


### PR DESCRIPTION
Naively addresses https://github.com/timbertson/dhall-render/issues/13.
If there is a need to treat top-level arrays as separate documents, perhaps a flag could be added instead?