### PR TITLE
Add github-hosted fallbacks for Prelude imports

### DIFF
--- a/self-install.dhall
+++ b/self-install.dhall
@@ -13,10 +13,16 @@ let default =
 let Prelude =
       { List.map
         =
-          https://prelude.dhall-lang.org/v16.0.0/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+            https://prelude.dhall-lang.org/v16.0.0/List/map
+              sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+          ? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v16.0.0/Prelude/List/map
+              sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
       , Text.concatSep
         =
-          https://prelude.dhall-lang.org/v16.0.0/Text/concatSep sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
+            https://prelude.dhall-lang.org/v16.0.0/Text/concatSep
+              sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
+          ? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v16.0.0/Prelude/Text/concatSep
+              sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
       }
 
 let makeExe =


### PR DESCRIPTION
There was a recent outage of `dhall-lang.org` which caused downstream workflows using `dhall-render` to fail due to these imports being unavailable. This PR simply adds a fallback to the github-hosted versions of these imports in case of another outage.